### PR TITLE
Compare prices as numbers

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -99,7 +99,7 @@ function evaulateAnswer(id) {
     name: selectedCard.name,
     url: selectedCard['scryfall_uri'],
     status:
-      selectedCard.prices[currency] > otherCard.prices[currency]
+      Number(selectedCard.prices[currency]) > Number(otherCard.prices[currency])
         ? STATUS_SUCCESS
         : selectedCard.prices[currency] === otherCard.prices[currency]
         ? STATUS_DRAW


### PR DESCRIPTION
When they are strings, the comparison leads to incorrect results